### PR TITLE
Labels with dots

### DIFF
--- a/example/labels.s
+++ b/example/labels.s
@@ -1,0 +1,122 @@
+.section .text
+.globl _start
+
+_start:
+    nop
+
+#basic labels
+
+L1:
+loop:
+start:
+main:
+exit:
+
+#underscore variants
+
+_loop:
+__start:
+____internal:
+label_1:
+label_123:
+a_b_c_d:
+
+#dot notation labels (local)
+
+.L1:
+.LoopStart:
+.Lmain_entry:
+.Lsystem_init:
+.Linternal_state_machine:
+
+#dot inside label (edge case - valid but uncommon)
+
+loop.start:
+loop.end:
+init.phase_1:
+state.machine.run:
+core.cpu.stage1:
+
+#snake_case equivalents
+
+loop_start:
+loop_end:
+init_phase_1:
+state_machine_run:
+core_cpu_pipeline_stage1:
+core_cpu_pipeline_stage2:
+app_v1_init_sequence:
+
+#numeric suffix labels
+
+label1:
+label2:
+label10:
+label100:
+version2_stage3:
+
+#long complex labels
+
+this_is_a_very_long_label_name:
+another_extremely_long_label_used_for_testing:
+recursive_parser_test_label_case:
+
+#mixed case (case-sensitive test)
+
+CamelCaseLabel:
+Mixed_Case_Label:
+UPPERCASELABEL:
+lowercaselabel:
+
+#edge but still valid (gnu/llvm accepted)
+
+label__internal__:
+.L__2:
+loop__inner:
+
+#label usage
+
+L1:
+    add x1, x2, x3
+    j loop
+
+loop:
+    addi x1, x1, -1
+    bnez x1, loop
+
+.L1:
+    nop
+
+main:
+    jal exit
+
+exit:
+    ret
+
+#multiple labels back-to-back
+
+a:
+b:
+c:
+d:
+    nop
+
+#snake_case structure labels
+
+state_init_phase1:
+state_init_phase2:
+state_run_phase_final:
+engine_core_v2_start:
+
+#nested style simulation
+
+system_boot_sequence_start:
+system_boot_sequence_check:
+system_boot_sequence_finish:
+
+#end
+
+_end:
+    li a7, 93
+    li a0, 0
+    ecall

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "RISC-V",
   "displayName": "RISC-V",
   "description": "Most Comprehensive RISC-V ASM Highlighting",
-  "version": "1.165.35",
+  "version": "1.165.36",
   "publisher": "sunshaoce",
   "homepage": "https://github.com/sunshaoce/RISC-V",
   "icon": "images/icon.png",

--- a/syntaxes/riscv.tmLanguage
+++ b/syntaxes/riscv.tmLanguage
@@ -1054,7 +1054,7 @@
         <string>(?x)(
           [1-9][0-9]*[bf] |
           \.L[A-Za-z0-9_\.]+:? |
-          \b\.?[A-Za-z0-9_]+:
+          \b\.?[A-Za-z0-9_\.]+:
           )</string>
         <key>name</key>
         <string>meta.function.label.riscv</string>


### PR DESCRIPTION
I was playing around and testing edge cases, and found that labels with dots inside weren't being detected.
They're edge cases and not recommended, but still valid and usable (GNU / LLVM compatible).

As shown below, for the valid label `label.with.dots:`, `label.with` wasn't detected as a label but as regular source code.
Only `.dots:` appeared as a label. It's caused by the regexp only allowing dots at the beginning (non-exportable labels convention).

<img width="400" alt="label with source" src="https://github.com/user-attachments/assets/5658b6a2-fc71-4abc-9ddf-0dafc289466d" />
<img width="400" alt="dots label" src="https://github.com/user-attachments/assets/16b4a989-0776-4a16-8fc9-7c6b05ff365f" />

I've modified the regexp to fix this, allowing dots inside labels. The whole `label.with.dots:` is now detected:

<img width="400" alt="fixed" src="https://github.com/user-attachments/assets/2b220f03-bc42-4104-9159-334d7f7422ed" />

To make this case easy to test, I've also added an example file with various labels.

⚠️ I've incremented the version number from .35 to .36, if you use a different versioning scheme, feel free to change it.